### PR TITLE
Fixes for [some] API change build errors

### DIFF
--- a/Source/Meadow.Core.Samples/Network/WiFi_Basics/MeadowApp.cs
+++ b/Source/Meadow.Core.Samples/Network/WiFi_Basics/MeadowApp.cs
@@ -4,6 +4,7 @@ using Meadow.Gateway.WiFi;
 using Meadow.Hardware;
 using System;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Threading.Tasks;
 
 namespace WiFi_Basics

--- a/Source/Meadow.Core.Samples/OS/BeginInvokeOnMainThread/BeginInvokeOnMainThread.csproj
+++ b/Source/Meadow.Core.Samples/OS/BeginInvokeOnMainThread/BeginInvokeOnMainThread.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>App</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meadow.Foundation" Version="0.*" />
     <ProjectReference Include="..\..\..\..\..\Meadow.Core\source\Meadow.F7\Meadow.F7.csproj" />
+    <ProjectReference Include="..\..\..\..\..\Meadow.Foundation\Source\Meadow.Foundation.Core\Meadow.Foundation.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- [x] Switch the BeginInvoke sample to a project ref
- [x] Add missing namespace for network interfaces

There are some network/config build errors still, but those require some API and best practices discussions. I'll separate those out to their own PR.